### PR TITLE
Add support for reading config from a string.

### DIFF
--- a/log4z.h
+++ b/log4z.h
@@ -267,6 +267,7 @@ public:
 	//! Config or overwrite configure
 	//! Needs to be called before ILog4zManager::Start,, OR Do not call.
 	virtual bool config(const char * configPath) = 0;
+	virtual bool configFromString(const char * config) = 0;
 
 	//! Create or overwrite logger, Total count limited by LOG4Z_LOGGER_MAX.
 	//! Needs to be called before ILog4zManager::Start, OR Do not call.


### PR DESCRIPTION
I wanted to be able to set the log path and log size limit without having to create a temporary file, write these parameters (which are retrieved from non-file locations, this is a hard requirement in my use case) into the file, destroy the file.
Therefore, I made this new configFromString() API, extracting most of the code from parseConfig() to a new parseConfigLine() function, so that both config() and configFromString() can use it.

Signed-off-by: Lionel Debroux lionel_debroux@yahoo.fr
