### PR TITLE
Windows console code page handling (ANSI->OEM)

### DIFF
--- a/log4z.cpp
+++ b/log4z.cpp
@@ -1178,10 +1178,16 @@ void LogerManager::showColorText(const char *text, int level)
     {
         return;
     }
-    else 
+    else
     {
         SetConsoleTextAttribute(hStd, LOG_COLOR[level]);
-        printf("%s", text);
+#ifdef LOG4Z_WINDOWS_OEM_CONSOLE
+        char out[LOG4Z_LOG_BUF_SIZE] = { 0 };
+        CharToOemBuffA(text, out, LOG4Z_LOG_BUF_SIZE);
+#else
+        char *out=text;
+#endif
+        printf("%s", out);
         SetConsoleTextAttribute(hStd, oldInfo.wAttributes);
     }
 #endif

--- a/log4z.cpp
+++ b/log4z.cpp
@@ -56,6 +56,7 @@
 #include <shlwapi.h>
 #include <process.h>
 #pragma comment(lib, "shlwapi")
+#pragma comment(lib, "User32.lib")
 #pragma warning(disable:4996)
 
 #else
@@ -1161,15 +1162,24 @@ LogerManager::~LogerManager()
 
 void LogerManager::showColorText(const char *text, int level)
 {
+
+#ifdef WIN32
+    char oem[LOG4Z_LOG_BUF_SIZE] = { 0 };
+    CharToOemBuffA(text, oem, LOG4Z_LOG_BUF_SIZE);
+#endif
+
     if (level <= LOG_LEVEL_DEBUG || level > LOG_LEVEL_FATAL)
     {
+#ifdef WIN32
+        printf("%s", oem);
+#else
         printf("%s", text);
+#endif
         return;
     }
 #ifndef WIN32
     printf("%s%s\e[0m", LOG_COLOR[level], text);
 #else
-
     AutoLock l(_scLock);
     HANDLE hStd = ::GetStdHandle(STD_OUTPUT_HANDLE);
     if (hStd == INVALID_HANDLE_VALUE) return;
@@ -1181,13 +1191,7 @@ void LogerManager::showColorText(const char *text, int level)
     else
     {
         SetConsoleTextAttribute(hStd, LOG_COLOR[level]);
-#ifdef LOG4Z_WINDOWS_OEM_CONSOLE
-        char out[LOG4Z_LOG_BUF_SIZE] = { 0 };
-        CharToOemBuffA(text, out, LOG4Z_LOG_BUF_SIZE);
-#else
-        char *out=text;
-#endif
-        printf("%s", out);
+        printf("%s", oem);
         SetConsoleTextAttribute(hStd, oldInfo.wAttributes);
     }
 #endif
@@ -1882,4 +1886,3 @@ ILog4zManager * ILog4zManager::getInstance()
 
 _ZSUMMER_LOG4Z_END
 _ZSUMMER_END
-

--- a/log4z.h
+++ b/log4z.h
@@ -171,8 +171,6 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-// need for ANSI->OEM conversion
-#pragma comment(lib, "User32.lib")
 #endif
 #include <vector>
 #include <map>
@@ -246,15 +244,9 @@ const bool LOG4Z_DEFAULT_MONTHDIR = false;
 const int LOG4Z_DEFAULT_LIMITSIZE = 100;
 //! default logger show suffix (file name and line number) 
 const bool LOG4Z_DEFAULT_SHOWSUFFIX = true;
-//! ANSI -> OEM codepage conversion on windows console, in mosc cases should be on, as usual source code and other resources are in ANSI coding, but default console have OEM code page
-#define LOG4Z_WINDOWS_OEM_CONSOLE
 ///////////////////////////////////////////////////////////////////////////
 //! -----------------------------------------------------------------------
 //////////////////////////////////////////////////////////////////////////
-
-
-
-
 
 #ifndef _ZSUMMER_BEGIN
 #define _ZSUMMER_BEGIN namespace zsummer {
@@ -264,9 +256,6 @@ const bool LOG4Z_DEFAULT_SHOWSUFFIX = true;
 #endif
 _ZSUMMER_BEGIN
 _ZSUMMER_LOG4Z_BEGIN
-
-
-
 
 //! log4z class
 class ILog4zManager
@@ -644,8 +633,3 @@ _ZSUMMER_LOG4Z_END
 _ZSUMMER_END
 
 #endif
-
-
-
-
-

--- a/log4z.h
+++ b/log4z.h
@@ -171,6 +171,8 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+// need for ANSI->OEM conversion
+#pragma comment(lib, "User32.lib")
 #endif
 #include <vector>
 #include <map>
@@ -244,7 +246,8 @@ const bool LOG4Z_DEFAULT_MONTHDIR = false;
 const int LOG4Z_DEFAULT_LIMITSIZE = 100;
 //! default logger show suffix (file name and line number) 
 const bool LOG4Z_DEFAULT_SHOWSUFFIX = true;
-
+//! ANSI -> OEM codepage conversion on windows console, in mosc cases should be on, as usual source code and other resources are in ANSI coding, but default console have OEM code page
+#define LOG4Z_WINDOWS_OEM_CONSOLE
 ///////////////////////////////////////////////////////////////////////////
 //! -----------------------------------------------------------------------
 //////////////////////////////////////////////////////////////////////////

--- a/test/fast_test.cpp
+++ b/test/fast_test.cpp
@@ -16,12 +16,6 @@ int main(int argc, char *argv[])
     ILog4zManager::getRef().setLoggerLevel(LOG4Z_MAIN_LOGGER_ID,LOG_LEVEL_TRACE);
     //LOGD: LOG WITH level LOG_DEBUG
     //LOGI: LOG WITH level LOG_INFO
-#ifdef WIN32
-    //begin test wstring(utf-16) log  string input....
-    WCHAR checkWCHAR[100] = L"check unicode WCHAR log";
-    std::wstring check_wstring = L"check wstring log";
-    LOGF(L"PATH=" << checkWCHAR << ":" << check_wstring);
-#endif
 
     //begin test stream log input....
     LOGT("stream input *** " << "LOGT LOGT LOGT LOGT" << " *** ");
@@ -74,6 +68,22 @@ int main(int argc, char *argv[])
 
     //begin test stream log big string more than buff size input....
     LOGD(str);
+
+#ifdef WIN32
+	// test ANSI->OEM codepage converting, only interesting in Windows environment
+	// source file contains characters in ANSI CP1251
+	// log file should contain same coding as source ANSI CP1251
+	// console output should be OEM 866
+	// sorry guys, this test is in russian
+	LOGI("const char[]: ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251) и в консоли (866)");
+	LOGI("Stream: " << "ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251) и в консоли (866)");
+	
+	//begin test wstring(utf-16) log string input....
+	WCHAR checkWCHAR[100] = L"ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251)";
+	std::wstring check_wstring = L"и в консоли (866)";
+	LOGI(L"WCHAR[] & wstring: " << checkWCHAR << " " << check_wstring);
+#endif
+
     LOGA("main quit ...");
     return 0;
 }

--- a/test/fast_test.cpp
+++ b/test/fast_test.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 	// console output should be OEM 866
 	// sorry guys, this test is in russian
 	LOGI("const char[]: ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251) и в консоли (866)");
-	LOGI("Stream: " << "ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251) и в консоли (866)");
+	LOGT("Stream: " << "ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251) и в консоли (866)");
 	
 	//begin test wstring(utf-16) log string input....
 	WCHAR checkWCHAR[100] = L"ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251)";


### PR DESCRIPTION
Short problem description is - Windows use OEM codepage for console and ANSI codepage for other purposes

Here are longer description https://en.wikipedia.org/wiki/Windows_code_page

