### PR TITLE
Revert "Windows console code page handling (ANSI->OEM)"

### DIFF
--- a/log4z.cpp
+++ b/log4z.cpp
@@ -56,7 +56,6 @@
 #include <shlwapi.h>
 #include <process.h>
 #pragma comment(lib, "shlwapi")
-#pragma comment(lib, "User32.lib")
 #pragma warning(disable:4996)
 
 #else
@@ -1162,24 +1161,15 @@ LogerManager::~LogerManager()
 
 void LogerManager::showColorText(const char *text, int level)
 {
-
-#ifdef WIN32
-    char oem[LOG4Z_LOG_BUF_SIZE] = { 0 };
-    CharToOemBuffA(text, oem, LOG4Z_LOG_BUF_SIZE);
-#endif
-
     if (level <= LOG_LEVEL_DEBUG || level > LOG_LEVEL_FATAL)
     {
-#ifdef WIN32
-        printf("%s", oem);
-#else
         printf("%s", text);
-#endif
         return;
     }
 #ifndef WIN32
     printf("%s%s\e[0m", LOG_COLOR[level], text);
 #else
+
     AutoLock l(_scLock);
     HANDLE hStd = ::GetStdHandle(STD_OUTPUT_HANDLE);
     if (hStd == INVALID_HANDLE_VALUE) return;
@@ -1188,10 +1178,10 @@ void LogerManager::showColorText(const char *text, int level)
     {
         return;
     }
-    else
+    else 
     {
         SetConsoleTextAttribute(hStd, LOG_COLOR[level]);
-        printf("%s", oem);
+        printf("%s", text);
         SetConsoleTextAttribute(hStd, oldInfo.wAttributes);
     }
 #endif
@@ -1886,3 +1876,4 @@ ILog4zManager * ILog4zManager::getInstance()
 
 _ZSUMMER_LOG4Z_END
 _ZSUMMER_END
+

--- a/log4z.h
+++ b/log4z.h
@@ -244,9 +244,14 @@ const bool LOG4Z_DEFAULT_MONTHDIR = false;
 const int LOG4Z_DEFAULT_LIMITSIZE = 100;
 //! default logger show suffix (file name and line number) 
 const bool LOG4Z_DEFAULT_SHOWSUFFIX = true;
+
 ///////////////////////////////////////////////////////////////////////////
 //! -----------------------------------------------------------------------
 //////////////////////////////////////////////////////////////////////////
+
+
+
+
 
 #ifndef _ZSUMMER_BEGIN
 #define _ZSUMMER_BEGIN namespace zsummer {
@@ -256,6 +261,9 @@ const bool LOG4Z_DEFAULT_SHOWSUFFIX = true;
 #endif
 _ZSUMMER_BEGIN
 _ZSUMMER_LOG4Z_BEGIN
+
+
+
 
 //! log4z class
 class ILog4zManager
@@ -633,3 +641,8 @@ _ZSUMMER_LOG4Z_END
 _ZSUMMER_END
 
 #endif
+
+
+
+
+

--- a/test/fast_test.cpp
+++ b/test/fast_test.cpp
@@ -16,6 +16,12 @@ int main(int argc, char *argv[])
     ILog4zManager::getRef().setLoggerLevel(LOG4Z_MAIN_LOGGER_ID,LOG_LEVEL_TRACE);
     //LOGD: LOG WITH level LOG_DEBUG
     //LOGI: LOG WITH level LOG_INFO
+#ifdef WIN32
+    //begin test wstring(utf-16) log  string input....
+    WCHAR checkWCHAR[100] = L"check unicode WCHAR log";
+    std::wstring check_wstring = L"check wstring log";
+    LOGF(L"PATH=" << checkWCHAR << ":" << check_wstring);
+#endif
 
     //begin test stream log input....
     LOGT("stream input *** " << "LOGT LOGT LOGT LOGT" << " *** ");
@@ -68,22 +74,6 @@ int main(int argc, char *argv[])
 
     //begin test stream log big string more than buff size input....
     LOGD(str);
-
-#ifdef WIN32
-	// test ANSI->OEM codepage converting, only interesting in Windows environment
-	// source file contains characters in ANSI CP1251
-	// log file should contain same coding as source ANSI CP1251
-	// console output should be OEM 866
-	// sorry guys, this test is in russian
-	LOGI("const char[]: ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251) и в консоли (866)");
-	LOGT("Stream: " << "ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251) и в консоли (866)");
-	
-	//begin test wstring(utf-16) log string input....
-	WCHAR checkWCHAR[100] = L"ANSI->OEM test, Эта строка должна быть читаема в логфайле (1251)";
-	std::wstring check_wstring = L"и в консоли (866)";
-	LOGI(L"WCHAR[] & wstring: " << checkWCHAR << " " << check_wstring);
-#endif
-
     LOGA("main quit ...");
     return 0;
 }


### PR DESCRIPTION
Reverts zsummer/log4z#34
in my windows page. the test code in fast_test.cpp display messy code, the console too. 
my windows page is chinese GB2312.  
